### PR TITLE
Update for React v15.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prepublish": "npm run clean && npm run lint && npm run build"
   },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.1"
+    "react": "0.14.x || ^15.0.1",
+    "prop-types": "^15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
@@ -50,6 +51,7 @@
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.8.0",
     "eslint-plugin-sorting": "^0.3.0",
+    "prop-types": "^15.5.0",
     "react": "^15.0.1",
     "react-dimensions": "^2.0.0-alpha1",
     "react-dom": "^15.0.1",

--- a/src/docs.jsx
+++ b/src/docs.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import dimensions from 'react-dimensions'
@@ -5,8 +6,8 @@ import Confetti from './react-confetti'
 
 const DimensionedExample = dimensions()(class Example extends React.Component {
   static propTypes = {
-    containerWidth: React.PropTypes.number,
-    containerHeight: React.PropTypes.number,
+    containerWidth: PropTypes.number,
+    containerHeight: PropTypes.number,
   }
   render() {
     const {

--- a/src/react-confetti.jsx
+++ b/src/react-confetti.jsx
@@ -1,17 +1,18 @@
+import PropTypes from 'prop-types'
 import React from 'react'
 import confetti from './confetti'
 
 export default class Confetti extends React.Component {
   static propTypes = {
-    style: React.PropTypes.object,
-    width: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
-    height: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]),
-    numberOfPieces: React.PropTypes.number,
-    friction: React.PropTypes.number,
-    wind: React.PropTypes.number,
-    gravity: React.PropTypes.number,
-    colors: React.PropTypes.arrayOf(React.PropTypes.string),
-    opacity: React.PropTypes.number,
+    style: PropTypes.object,
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    numberOfPieces: PropTypes.number,
+    friction: PropTypes.number,
+    wind: PropTypes.number,
+    gravity: PropTypes.number,
+    colors: PropTypes.arrayOf(PropTypes.string),
+    opacity: PropTypes.number,
   }
 
   static defaultProps = {


### PR DESCRIPTION
Require `prop-types` package and import PropTypes from it.

fixes #9.