### PR TITLE
enable spread operator plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "env": {
       "production": {
         "plugins": [
-          "transform-react-remove-prop-types"
+          "transform-react-remove-prop-types",
+          "transform-object-rest-spread"
         ]
       }
     }


### PR DESCRIPTION
Turns out that the spread operator on Line 83 of `src/react-confetti.jsx` was being completely ignored because the babel config in `package.json` didn't have `transform-object-rest-spread` plugin enabled. 

I think you get it for free with the npm library `babel-preset-stage-1`.

(This will allows you to pass-through the className prop.)