### PR TITLE
Fix rotation jump

### DIFF
--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -8,8 +8,8 @@ export enum ParticleShape {
 }
 
 enum RotationDirection {
-  Positive,
-  Negative,
+  Positive = 1,
+  Negative = -1,
 }
 
 export default class Particle {
@@ -29,7 +29,7 @@ export default class Particle {
     this.angularSpin = randomRange(-0.2, 0.2)
     this.color = colors[Math.floor(Math.random() * colors.length)]
     this.rotateY = randomRange(0, 1)
-    this.rotationDirection = RotationDirection.Positive
+    this.rotationDirection = randomRange(0, 1) ? RotationDirection.Positive : RotationDirection.Negative
   }
   context: CanvasRenderingContext2D
   radius: number
@@ -43,6 +43,7 @@ export default class Particle {
   angle: number
   angularSpin: number
   color: string
+  // Actually used as scaleY to simulate rotation cheaply
   rotateY: number
   rotationDirection: RotationDirection
   getOptions: () => IConfettiOptions

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -24,6 +24,7 @@ export default class Particle {
     this.angularSpin = randomRange(-0.2, 0.2)
     this.color = colors[Math.floor(Math.random() * colors.length)]
     this.rotateY = randomRange(0, 1)
+    this.rotateDirection = 1;
   }
   context: CanvasRenderingContext2D
   radius: number
@@ -54,11 +55,15 @@ export default class Particle {
     this.vx += wind
     this.vx *= friction
     this.vy *= friction
-    if(this.rotateY < 1) {
-      this.rotateY += 0.1
-    } else {
-      this.rotateY = -1
+    if(this.rotateY >= 1 && this.rotateDirection === 1) {
+      this.rotateDirection = -1
+    } else if(this.rotateY <= -1 && this.rotateDirection === -1) {
+      this.rotateDirection = 1
     }
+
+    const rotateDelta = 0.1 * this.rotateDirection
+
+    this.rotateY += rotateDelta
     this.angle += this.angularSpin
     this.context.save()
     this.context.translate(this.x, this.y)

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -7,6 +7,11 @@ export enum ParticleShape {
   Strip,
 }
 
+enum RotationDirection {
+  Positive,
+  Negative,
+}
+
 export default class Particle {
   constructor(context: CanvasRenderingContext2D, getOptions: () => IConfettiOptions, x: number, y: number) {
     this.getOptions = getOptions
@@ -24,7 +29,7 @@ export default class Particle {
     this.angularSpin = randomRange(-0.2, 0.2)
     this.color = colors[Math.floor(Math.random() * colors.length)]
     this.rotateY = randomRange(0, 1)
-    this.rotateDirection = 1
+    this.rotationDirection = RotationDirection.Positive
   }
   context: CanvasRenderingContext2D
   radius: number
@@ -39,6 +44,7 @@ export default class Particle {
   angularSpin: number
   color: string
   rotateY: number
+  rotationDirection: RotationDirection
   getOptions: () => IConfettiOptions
 
   update() {
@@ -55,13 +61,13 @@ export default class Particle {
     this.vx += wind
     this.vx *= friction
     this.vy *= friction
-    if(this.rotateY >= 1 && this.rotateDirection === 1) {
-      this.rotateDirection = -1
-    } else if(this.rotateY <= -1 && this.rotateDirection === -1) {
-      this.rotateDirection = 1
+    if(this.rotateY >= 1 && this.rotationDirection === RotationDirection.Positive) {
+      this.rotationDirection = RotationDirection.Negative
+    } else if(this.rotateY <= -1 && this.rotationDirection === RotationDirection.Negative) {
+      this.rotationDirection = RotationDirection.Positive
     }
 
-    const rotateDelta = 0.1 * this.rotateDirection
+    const rotateDelta = 0.1 * this.rotationDirection
 
     this.rotateY += rotateDelta
     this.angle += this.angularSpin

--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -24,7 +24,7 @@ export default class Particle {
     this.angularSpin = randomRange(-0.2, 0.2)
     this.color = colors[Math.floor(Math.random() * colors.length)]
     this.rotateY = randomRange(0, 1)
-    this.rotateDirection = 1;
+    this.rotateDirection = 1
   }
   context: CanvasRenderingContext2D
   radius: number


### PR DESCRIPTION
This wasn't noticeable on the demo (I think because the example shapes are symmetrical) but I'm drawing only custom shapes and there was a noticeable jump when the `rotateY` was set back to `-1`.

This change increments and decrements `rotateY` smoothly between -1 and 1.