### PR TITLE
Export same class member as default export

### DIFF
--- a/src/ReactConfetti.tsx
+++ b/src/ReactConfetti.tsx
@@ -4,7 +4,7 @@ import Confetti, { IConfettiOptions, confettiDefaults } from './Confetti'
 export type Ref = HTMLCanvasElement
 
 export type Props = Partial<IConfettiOptions> & CanvasHTMLAttributes<HTMLCanvasElement> & {
-  canvasRef: React.RefObject<HTMLCanvasElement>
+  canvasRef?: React.RefObject<HTMLCanvasElement>
 }
 
 export class ReactConfetti extends Component<Props> {

--- a/src/ReactConfetti.tsx
+++ b/src/ReactConfetti.tsx
@@ -1,16 +1,18 @@
-import React, { Component, CanvasHTMLAttributes } from 'react'
+import React, { Component, CanvasHTMLAttributes, NamedExoticComponent } from 'react'
 import Confetti, { IConfettiOptions, confettiDefaults } from './Confetti'
 
 export type Ref = HTMLCanvasElement
 
-export type Props = Partial<IConfettiOptions> & CanvasHTMLAttributes<HTMLCanvasElement> & {
-  canvasRef?: React.RefObject<HTMLCanvasElement>
+export type Props = Partial<IConfettiOptions> & NamedExoticComponent & CanvasHTMLAttributes<HTMLCanvasElement> & {
+  canvasRef: React.RefObject<HTMLCanvasElement>
 }
 
-export class ReactConfetti extends Component<Props> {
+class ReactConfettiInternal extends Component<Props> {
   static readonly defaultProps = {
     ...confettiDefaults,
   }
+
+  static readonly displayName = 'ReactConfetti'
 
   constructor(props: Props, ...rest: any[]) {
     super(props, ...rest)
@@ -87,6 +89,8 @@ function extractCanvasProps(props: Partial<IConfettiOptions> | any): [Partial<IC
   return [confettiOptions, rest, refs]
 }
 
-export default React.forwardRef<Ref, Props>((props, ref) => (
-  <ReactConfetti canvasRef={ref} {...props} />
+export const ReactConfetti = React.forwardRef<Ref, Props>((props, ref) => (
+  <ReactConfettiInternal canvasRef={ref} {...props} />
 ))
+
+export default ReactConfetti


### PR DESCRIPTION
While using `react-confetti@3.1.2`, it requires a `canvasRef` ref be passed in as a prop to the `Confetti` component. Looking at the constructor, if not provided, it will create and use a ref by default. It should be that the `canvasRef` prop is optional.  

As a workaround, the `canvasRef` I passed to `Confetti` is just an arbitrary ref created with `React.createRef`, exactly the same as the one the component creates internally if `props.canasRef` is undefined.