### PR TITLE
Allow react 17 in peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "develop": "start-storybook -p 3000"
   },
   "peerDependencies": {
-    "react": "^16.3.0"
+    "react": "^16.3.0 || ^17.0.1"
   },
   "dependencies": {
     "tween-functions": "^1.2.0"


### PR DESCRIPTION
Hi,

Since react 17 is backwards compatible with react 16, it's safe to allow it as a peer dependency.

This resolves clean installs on react 17 and closes #99

Please create a release if you end up merging these changes :)