### PR TITLE
Use passed in styles to override existing styles

### DIFF
--- a/src/ReactConfetti.tsx
+++ b/src/ReactConfetti.tsx
@@ -60,7 +60,7 @@ class ReactConfettiInternal extends Component<Props> {
         height={confettiOptions.height}
         ref={this.canvas}
         {...passedProps}
-        style={canvasStyles}
+        style={{...canvasStyles, ...passedProps.style}}
       />
     )
   }


### PR DESCRIPTION
I'd love to use react-confetti but the z-index set won't work within our existing CSS framework. 

This change allows styles in the props to override the default styles set in this package. 