### PR TITLE
docs: useWindowSize import

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install react-confetti
 
 ```jsx
 import React from 'react'
-import useWindowSize from 'react-use/lib/useWindowSize'
+import { useWindowSize } from 'react-use'
 import Confetti from 'react-confetti'
 
 export default () => {


### PR DESCRIPTION
Update README code snippet for `useWindowSize` import as [documented](https://github.com/streamich/react-use/blob/master/docs/useWindowSize.md) in related hook.