### PR TITLE
Make confetti speed consistent between different refresh rates

### DIFF
--- a/src/Particle.ts
+++ b/src/Particle.ts
@@ -12,6 +12,8 @@ enum RotationDirection {
   Negative = -1,
 }
 
+const DEFAULT_FRAME_TIME = 1000 / 60
+
 export default class Particle {
   constructor(
     context: CanvasRenderingContext2D,
@@ -76,14 +78,15 @@ export default class Particle {
 
   getOptions: () => IConfettiOptions
 
-  update() {
+  update(elapsed: number) {
     const { gravity, wind, friction, opacity, drawShape } = this.getOptions()
-    this.x += this.vx
-    this.y += this.vy
-    this.vy += gravity
-    this.vx += wind
-    this.vx *= friction
-    this.vy *= friction
+    const frameTimeMultiplier = elapsed / DEFAULT_FRAME_TIME
+    this.x += this.vx * frameTimeMultiplier
+    this.y += this.vy * frameTimeMultiplier
+    this.vy += gravity * frameTimeMultiplier
+    this.vx += wind * frameTimeMultiplier
+    this.vx *= friction ** frameTimeMultiplier
+    this.vy *= friction ** frameTimeMultiplier
     if (
       this.rotateY >= 1 &&
       this.rotationDirection === RotationDirection.Positive
@@ -96,7 +99,7 @@ export default class Particle {
       this.rotationDirection = RotationDirection.Positive
     }
 
-    const rotateDelta = 0.1 * this.rotationDirection
+    const rotateDelta = 0.1 * this.rotationDirection * frameTimeMultiplier
 
     this.rotateY += rotateDelta
     this.angle += this.angularSpin

--- a/src/ParticleGenerator.ts
+++ b/src/ParticleGenerator.ts
@@ -6,7 +6,7 @@ import { randomRange } from './utils'
 export interface IParticleGenerator extends IRect {
   removeParticleAt: (index: number) => void
   getParticle: () => void
-  animate: () => boolean
+  animate: (elapsed: number) => boolean
   particles: Particle[]
   particlesGenerated: number
 }
@@ -38,7 +38,7 @@ export default class ParticleGenerator implements IParticleGenerator {
 
   lastNumberOfPieces = 0
 
-  tweenInitTime: number = Date.now()
+  tweenInitTime: number = 0
 
   particles: Particle[] = []
 
@@ -59,7 +59,7 @@ export default class ParticleGenerator implements IParticleGenerator {
     )
   }
 
-  animate = (): boolean => {
+  animate = (elapsed: number): boolean => {
     const { canvas, context, particlesGenerated, lastNumberOfPieces } = this
     const {
       run,
@@ -76,24 +76,19 @@ export default class ParticleGenerator implements IParticleGenerator {
     const nP = this.particles.length
     const activeCount = recycle ? nP : particlesGenerated
 
-    const now = Date.now()
-
     // Initial population
     if (activeCount < numberOfPieces) {
       // Use the numberOfPieces prop as a key to reset the easing timing
       if (lastNumberOfPieces !== numberOfPieces) {
-        this.tweenInitTime = now
+        this.tweenInitTime = 0
         this.lastNumberOfPieces = numberOfPieces
       }
-      const { tweenInitTime } = this
+
       // Add more than one piece per loop, otherwise the number of pieces would
       // be limitted by the RAF framerate
-      const progressTime =
-        now - tweenInitTime > tweenDuration
-          ? tweenDuration
-          : Math.max(0, now - tweenInitTime)
+      this.tweenInitTime += elapsed
       const tweenedVal = tweenFunction(
-        progressTime,
+        this.tweenInitTime,
         activeCount,
         numberOfPieces,
         tweenDuration,
@@ -119,7 +114,7 @@ export default class ParticleGenerator implements IParticleGenerator {
     // Maintain the population
     this.particles.forEach((p, i) => {
       // Update each particle's position
-      p.update()
+      p.update(elapsed)
       // Prune the off-canvas particles
       if (
         p.y > canvas.height ||


### PR DESCRIPTION
Currently, particles have per-frame physics; the amount a particle moves per second depends entirely on how many frames have elapsed during the second. This is problematic when using a display with a refresh rate higher (or lower) than the most common 60hz.

This PR addresses this issue by utilising the elapsed time between frames to proportionally move/rotate/accelerate particles, so that no matter what the monitor's refresh rate is, confetti will consistently move at the same rate between devices.

This will fix https://github.com/alampros/react-confetti/issues/117 - it's marked as resolved already, but the PR that closed it doesn't actually address the issue, just exposes a prop to limit the FPS