### PR TITLE
Bugfix - Fixing tweening values after variable frame time change

### DIFF
--- a/src/ParticleGenerator.ts
+++ b/src/ParticleGenerator.ts
@@ -40,6 +40,8 @@ export default class ParticleGenerator implements IParticleGenerator {
 
   tweenProgress: number = 0
 
+  tweenFrom: number = 0;
+
   particles: Particle[] = []
 
   particlesGenerated = 0
@@ -81,6 +83,7 @@ export default class ParticleGenerator implements IParticleGenerator {
       // Use the numberOfPieces prop as a key to reset the easing timing
       if (lastNumberOfPieces !== numberOfPieces) {
         this.tweenProgress = 0
+        this.tweenFrom = activeCount;
         this.lastNumberOfPieces = numberOfPieces
       }
 
@@ -89,7 +92,7 @@ export default class ParticleGenerator implements IParticleGenerator {
       this.tweenInitTime += elapsed
       const tweenedVal = tweenFunction(
         this.tweenProgress,
-        activeCount,
+        this.tweenFrom,
         numberOfPieces,
         tweenDuration,
       )

--- a/src/ParticleGenerator.ts
+++ b/src/ParticleGenerator.ts
@@ -87,9 +87,8 @@ export default class ParticleGenerator implements IParticleGenerator {
         this.lastNumberOfPieces = numberOfPieces
       }
 
-      // Add more than one piece per loop, otherwise the number of pieces would
-      // be limitted by the RAF framerate
-      this.tweenInitTime += elapsed
+      // Clamp tweenProgress between 0 and tweenDuration
+      this.tweenProgress = Math.min(tweenDuration, Math.max(0, this.tweenProgress + elapsed))
       const tweenedVal = tweenFunction(
         this.tweenProgress,
         this.tweenFrom,

--- a/src/ParticleGenerator.ts
+++ b/src/ParticleGenerator.ts
@@ -38,7 +38,7 @@ export default class ParticleGenerator implements IParticleGenerator {
 
   lastNumberOfPieces = 0
 
-  tweenInitTime = 0
+  tweenProgress: number = 0
 
   particles: Particle[] = []
 
@@ -80,7 +80,7 @@ export default class ParticleGenerator implements IParticleGenerator {
     if (activeCount < numberOfPieces) {
       // Use the numberOfPieces prop as a key to reset the easing timing
       if (lastNumberOfPieces !== numberOfPieces) {
-        this.tweenInitTime = 0
+        this.tweenProgress = 0
         this.lastNumberOfPieces = numberOfPieces
       }
 
@@ -88,7 +88,7 @@ export default class ParticleGenerator implements IParticleGenerator {
       // be limitted by the RAF framerate
       this.tweenInitTime += elapsed
       const tweenedVal = tweenFunction(
-        this.tweenInitTime,
+        this.tweenProgress,
         activeCount,
         numberOfPieces,
         tweenDuration,


### PR DESCRIPTION
Updating tweening logic to always tween values from 0 (or the most recent `tweenFrom` value) to ensure smooth addition of particles. Also re-adding logic to clamp the tweenProgress between 0 and `tweenDuration`.

Fixes the issue raised in https://github.com/alampros/react-confetti/pull/171#issuecomment-2691860864 by @alampros

Apologies for introducing this bug!

