### PR TITLE
revert '* as  tweens' import introduced with v6.2 due to vitest tests…

### DIFF
--- a/src/Confetti.ts
+++ b/src/Confetti.ts
@@ -1,4 +1,4 @@
-import * as tweens from 'tween-functions'
+import { easeInOutQuad } from 'tween-functions'
 import ParticleGenerator from './ParticleGenerator'
 import { IRect } from './Rect'
 
@@ -141,7 +141,7 @@ export const confettiDefaults: Pick<
   ],
   opacity: 1.0,
   debug: false,
-  tweenFunction: tweens.easeInOutQuad,
+  tweenFunction: easeInOutQuad,
   tweenDuration: 5000,
   recycle: true,
   run: true,


### PR DESCRIPTION
… failing because of the cjs import

I work on a private repository where tests started failing after bumping react-confetti from v6.1 to v6.4.
Turns out the cjs import in Confetti.ts makes vitest fail with an error saying tweenFunction is not a function.
Sorry for not being able to provide codesamples.